### PR TITLE
Add Flutter skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@ To run the devserver:
 npm install
 npm run dev
 ```
+
+## Flutter version
+
+There is a minimal Flutter port of the app in the `flutter_app` directory.
+To run it you will need the Flutter SDK installed. From the repository root:
+
+```
+cd flutter_app
+flutter run
+```

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'screens/home_page.dart';
+import 'screens/login_page.dart';
+import 'screens/profile_page.dart';
+import 'screens/signal_detail_page.dart';
+import 'screens/watchlist_page.dart';
+
+void main() {
+  runApp(const LuminaApp());
+}
+
+class LuminaApp extends StatelessWidget {
+  const LuminaApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Lumina Signals',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        useMaterial3: true,
+      ),
+      initialRoute: '/',
+      routes: {
+        '/': (context) => const HomePage(),
+        '/login': (context) => const LoginPage(),
+        '/watchlist': (context) => const WatchlistPage(),
+        '/profile': (context) => const ProfilePage(),
+        '/signal': (context) => const SignalDetailPage(),
+      },
+    );
+  }
+}

--- a/flutter_app/lib/screens/home_page.dart
+++ b/flutter_app/lib/screens/home_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Live Signals')),
+      body: const Center(
+        child: Text('TODO: show list of signals'),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/screens/login_page.dart
+++ b/flutter_app/lib/screens/login_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class LoginPage extends StatelessWidget {
+  const LoginPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: const Center(
+        child: Text('TODO: implement login form'),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/screens/profile_page.dart
+++ b/flutter_app/lib/screens/profile_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class ProfilePage extends StatelessWidget {
+  const ProfilePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profile')),
+      body: const Center(
+        child: Text('TODO: show profile'),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/screens/signal_detail_page.dart
+++ b/flutter_app/lib/screens/signal_detail_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class SignalDetailPage extends StatelessWidget {
+  const SignalDetailPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Signal Detail')),
+      body: const Center(
+        child: Text('TODO: show signal detail'),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/screens/watchlist_page.dart
+++ b/flutter_app/lib/screens/watchlist_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class WatchlistPage extends StatelessWidget {
+  const WatchlistPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Watchlist')),
+      body: const Center(
+        child: Text('TODO: show watchlist'),
+      ),
+    );
+  }
+}

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -1,0 +1,12 @@
+name: lumina_signals_flutter
+version: 0.1.0
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add Flutter skeleton alongside React app
- document Flutter app in README

## Testing
- `npm install`
- `npm run build` *(fails: TS6133 unused variable errors)*
- `npm run lint` *(fails: missing ESLint config)*


------
https://chatgpt.com/codex/tasks/task_e_68729595e8b0832da0aee3a57fcfd788