### PR TITLE
Add Flutter version of homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Node
+node_modules/
+.env
+
+# Flutter
+build/
+.dart_tool/
+.packages
+flutter_app/.idea/
+flutter_app/.flutter-plugins
+flutter_app/.flutter-plugins-dependencies
+flutter_app/.metadata
+flutter_app/linux/
+flutter_app/macos/
+flutter_app/web/
+flutter_app/windows/

--- a/flutter_app/lib/home_screen.dart
+++ b/flutter_app/lib/home_screen.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'signal_card.dart';
+
+class Signal {
+  final String asset;
+  final String timeframe;
+  final double entry;
+  final double takeProfit;
+  final double stopLoss;
+  final String confidence;
+  final String status;
+
+  const Signal({
+    required this.asset,
+    required this.timeframe,
+    required this.entry,
+    required this.takeProfit,
+    required this.stopLoss,
+    required this.confidence,
+    required this.status,
+  });
+}
+
+class HomeScreen extends StatefulWidget {
+  final VoidCallback onToggleTheme;
+  const HomeScreen({super.key, required this.onToggleTheme});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  final List<Signal> _signals = const [
+    Signal(
+        asset: 'XAUUSD',
+        timeframe: 'H4',
+        entry: 2387.50,
+        takeProfit: 2415.00,
+        stopLoss: 2370.25,
+        confidence: 'High',
+        status: 'Active'),
+    Signal(
+        asset: 'BTCUSD',
+        timeframe: 'D1',
+        entry: 64250.00,
+        takeProfit: 68750.00,
+        stopLoss: 62500.00,
+        confidence: 'Medium',
+        status: 'Waiting'),
+    Signal(
+        asset: 'EURUSD',
+        timeframe: 'H1',
+        entry: 1.0845,
+        takeProfit: 1.0795,
+        stopLoss: 1.0870,
+        confidence: 'High',
+        status: 'TP Hit'),
+    Signal(
+        asset: 'ETHUSD',
+        timeframe: 'H4',
+        entry: 3150.00,
+        takeProfit: 3350.00,
+        stopLoss: 3050.00,
+        confidence: 'Medium',
+        status: 'SL Hit'),
+  ];
+
+  String _filter = 'All';
+
+  List<Signal> get _filteredSignals {
+    if (_filter == 'All') return _signals;
+    if (_filter == 'Active') {
+      return _signals.where((s) => s.status == 'Active').toList();
+    }
+    if (_filter == 'High Confidence') {
+      return _signals.where((s) => s.confidence == 'High').toList();
+    }
+    return _signals;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Live Signals'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.brightness_6),
+            onPressed: widget.onToggleTheme,
+          )
+        ],
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(
+              'Real-time trading opportunities around key market levels',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+          SizedBox(
+            height: 40,
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              children: [
+                const SizedBox(width: 16),
+                _buildFilterChip('All'),
+                _buildFilterChip('Active'),
+                _buildFilterChip('High Confidence'),
+                const SizedBox(width: 16),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: _filteredSignals.length,
+              itemBuilder: (context, index) {
+                final signal = _filteredSignals[index];
+                return SignalCard(signal: signal);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilterChip(String label) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 8),
+      child: ChoiceChip(
+        label: Text(label),
+        selected: _filter == label,
+        onSelected: (_) {
+          setState(() {
+            _filter = label;
+          });
+        },
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'home_screen.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  ThemeMode _mode = ThemeMode.system;
+
+  void _toggleTheme() {
+    setState(() {
+      _mode = _mode == ThemeMode.dark ? ThemeMode.light : ThemeMode.dark;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Lumina Signals',
+      themeMode: _mode,
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        useMaterial3: true,
+      ),
+      darkTheme: ThemeData(
+        brightness: Brightness.dark,
+        colorScheme: ColorScheme.fromSeed(
+            seedColor: Colors.blue, brightness: Brightness.dark),
+        useMaterial3: true,
+      ),
+      home: HomeScreen(onToggleTheme: _toggleTheme),
+    );
+  }
+}

--- a/flutter_app/lib/signal_card.dart
+++ b/flutter_app/lib/signal_card.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'home_screen.dart';
+
+class SignalCard extends StatelessWidget {
+  final Signal signal;
+  const SignalCard({super.key, required this.signal});
+
+  Color _confidenceColor(String level, BuildContext context) {
+    switch (level) {
+      case 'High':
+        return Colors.green.shade600;
+      case 'Medium':
+        return Colors.amber.shade600;
+      case 'Low':
+        return Colors.red.shade600;
+      default:
+        return Theme.of(context).colorScheme.primary;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(signal.asset,
+                        style: Theme.of(context).textTheme.titleMedium),
+                    Text(signal.timeframe,
+                        style: Theme.of(context).textTheme.bodySmall),
+                  ],
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).colorScheme.primary,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        signal.status,
+                        style: const TextStyle(color: Colors.white, fontSize: 12),
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: _confidenceColor(signal.confidence, context),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        signal.confidence,
+                        style: const TextStyle(color: Colors.white, fontSize: 12),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                _buildLabel('Entry', signal.entry.toStringAsFixed(2),
+                    color: Colors.blue.shade600),
+                _buildLabel('SL', signal.stopLoss.toStringAsFixed(2),
+                    color: Colors.red.shade600),
+                _buildLabel('TP', signal.takeProfit.toStringAsFixed(2),
+                    color: Colors.green.shade600),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () {},
+                    child: const Text('View Analysis'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () {},
+                    child: const Text('Follow'),
+                  ),
+                ),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLabel(String title, String value, {required Color color}) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: const TextStyle(fontSize: 12)),
+        Row(
+          children: [
+            Container(
+              width: 6,
+              height: 6,
+              margin: const EdgeInsets.only(right: 4),
+              decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+            ),
+            Text(value, style: const TextStyle(fontWeight: FontWeight.w500)),
+          ],
+        )
+      ],
+    );
+  }
+}

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -1,0 +1,20 @@
+name: lumina_signals
+description: Flutter version of Lumina Chart signals homepage.
+publish_to: 'none'
+version: 1.0.0
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- create Flutter module under `flutter_app`
- implement `main.dart` with basic theming and routing
- implement `home_screen.dart` with filter chips and mock signal data
- add reusable `signal_card.dart` widget
- add Flutter-aware `.gitignore`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a224513c832dbc97e081ab352d4b